### PR TITLE
feat: allow to ignore already existing handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Fastify >=3
 
 ## Caveats
 
-- Don't register signal handlers otherwise except with this plugin.
+- Don't register signal handlers otherwise except with this plugin unless you are absolutely sure how they work together (use `opts.ignoreExistingHandlers` to enable).
 - Can't be used with a different logger other than [Pino](https://github.com/pinojs/pino) because we use the child logger feature to encapsulate the logs.
 - Use fastify `onClose` hook to release resources in your plugin.
 - The process will be exited after a certain timeout (Default 10 seconds) to protect against stuck process.

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ export type fastifyGracefulShutdownOpt = {
   timeout?: number
   resetHandlersOnInit?: boolean
   handlerEventListener?: EventEmitter & { exit(code?: number): never; }
+  ignoreExistingHandlers?: boolean
 }
 
 export const fastifyGracefulShutdown: FastifyPluginCallback<fastifyGracefulShutdownOpt>

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function fastifyGracefulShutdown(fastify, opts, next) {
   const timeout = opts.timeout || 10000
   const signals = ['SIGINT', 'SIGTERM']
   const handlerEventListener = opts.handlerEventListener || process
+  const ignoreExistingHandlers = opts.ignoreExistingHandlers || false
 
   // Remove preexisting listeners if already created by previous instance of same plugin
   if (opts.resetHandlersOnInit) {
@@ -21,15 +22,17 @@ function fastifyGracefulShutdown(fastify, opts, next) {
     registeredListeners = []
   }
 
-  for (let i = 0; i < signals.length; i++) {
-    let signal = signals[i]
-    if (handlerEventListener.listenerCount(signal) > 0) {
-      next(
-        new Error(
-          `${signal} handler was already registered use fastify.gracefulShutdown`
+  if(!ignoreExistingHandlers) {
+    for (let i = 0; i < signals.length; i++) {
+      let signal = signals[i]
+      if (handlerEventListener.listenerCount(signal) > 0) {
+        next(
+          new Error(
+            `${signal} handler was already registered use fastify.gracefulShutdown`
+          )
         )
-      )
-      return
+        return
+      }
     }
   }
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,7 +3,7 @@ import plugin from '.'
 
 const app = fastify()
 
-app.register(plugin, { timeout: 1, resetHandlersOnInit: false, handlerEventListener: process })
+app.register(plugin, { timeout: 1, resetHandlersOnInit: false, handlerEventListener: process, ignoreExistingHandlers: false })
 app.register(plugin, { timeout: 1 })
 
 app.gracefulShutdown((signal: string, next: () => void) => {})

--- a/test.js
+++ b/test.js
@@ -60,4 +60,110 @@ describe('fastify-graceful-shutdown', () => {
     expect(addedListeners.length).to.eq(2)
     expect(removedListeners.length).to.eq(0)
   })
+
+  it('does not allow to register multiple handlers by default', async function() {
+    this.timeout(10000)
+    const fastify = Fastify()
+
+    const mockEventListener = {
+      once: (signal, listener) => {},
+      listenerCount: (signal) => 1,
+    }
+    fastify.register(fastifyGracefulShutdown, { handlerEventListener: mockEventListener })
+
+    fastify.after(() => {
+      expect(fastify.gracefulShutdown).to.be.undefined
+    })
+
+    let error
+    try {
+      await fastify.ready()
+    }
+    catch(err) {
+      error = err
+    }
+    expect(error).to.be.a('Error');
+    expect(error.message).to.eq('SIGINT handler was already registered use fastify.gracefulShutdown');
+  })
+
+  it('ignores already registered handlers', async function() {
+    this.timeout(10000)
+    const fastify = Fastify()
+
+    let removedListeners = []
+    let addedListeners = []
+    const mockEventListener = {
+      removeListener: (signal, listener) => { timeout: 1, removedListeners.push({signal, listener})},
+      once: (signal, listener) => { addedListeners.push({signal, listener})},
+      listenerCount: (signal) => (addedListeners.length + 1) - removedListeners.length,
+      exit: (exitCode) => {}
+    }
+    fastify.register(fastifyGracefulShutdown, { handlerEventListener: mockEventListener, ignoreExistingHandlers: true })
+
+    fastify.after(() => {
+      fastify.gracefulShutdown((signal, next) => {
+        fastify.log.info('Starting graceful shutdown')
+        next()
+      })
+    })
+
+    await fastify.ready()
+    await fastify.close()
+
+    expect(addedListeners.length).to.eq(2)
+    expect(removedListeners.length).to.eq(0)
+  })
+
+  it('does not allow to register multiple handlers by default', async function() {
+    this.timeout(10000)
+    const fastify = Fastify()
+
+    const mockEventListener = {
+      once: (signal, listener) => {},
+      listenerCount: (signal) => 1,
+    }
+    fastify.register(fastifyGracefulShutdown, { handlerEventListener: mockEventListener })
+
+    fastify.after(() => {
+      expect(fastify.gracefulShutdown).to.be.undefined
+    })
+
+    let error
+    try {
+      await fastify.ready()
+    }
+    catch(err) {
+      error = err
+    }
+    expect(error).to.be.a('Error')
+    expect(error.message).to.eql('SIGINT handler was already registered use fastify.gracefulShutdown')
+  })
+
+  it('ignores already registered handlers', async function() {
+    this.timeout(10000)
+    const fastify = Fastify()
+
+    let removedListeners = []
+    let addedListeners = []
+    const mockEventListener = {
+      removeListener: (signal, listener) => { timeout: 1, removedListeners.push({signal, listener})},
+      once: (signal, listener) => { addedListeners.push({signal, listener})},
+      listenerCount: (signal) => (addedListeners.length + 1) - removedListeners.length,
+      exit: (exitCode) => {}
+    }
+    fastify.register(fastifyGracefulShutdown, { handlerEventListener: mockEventListener, ignoreExistingHandlers: true })
+
+    fastify.after(() => {
+      fastify.gracefulShutdown((signal, next) => {
+        fastify.log.info('Starting graceful shutdown')
+        next()
+      })
+    })
+
+    await fastify.ready()
+    await fastify.close()
+
+    expect(addedListeners.length).to.eq(2)
+    expect(removedListeners.length).to.eq(0)
+  })
 })


### PR DESCRIPTION
Hi, 
in relation to https://github.com/hemerajs/fastify-graceful-shutdown/issues/36 i created an option to skip the check for existing handlers. Change is backwards compatible.
Thanks