### PR TITLE
feat!: terminate with original signal unless `useExit0` option passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ npm install --save fastify-graceful-shutdown
 fastify.register(require('fastify-graceful-shutdown'))
 ```
 
+## Passing options
+
+- `timeout` (number) - The timeout in milliseconds to wait before forceful shutdown. Default is 10 seconds.
+- `useExit0` (boolean) - Exit with code 0 after successful shutdown, or 1 if reaching the timeout. Otherwise will exit with the received signal, eg `SIGTERM` or `SIGINT`. Default is `false`.
+- `resetHandlersOnInit` (boolean) - Remove preexisting listeners if already created by previous instance of same plugin. Default is `false`.
+
+```js
+fastify.register(require('fastify-graceful-shutdown'), {
+  timeout: 5000,
+  useExit0: true,
+  resetHandlersOnInit: true,
+})
+```
+
 ## Usage
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,7 @@ type FastifyGracefulShutdownPlugin =
 
 declare module 'fastify' {
   interface FastifyInstance {
-    gracefulShutdown(
-      handler: (signal: string) => Promise<void> | void,
-    ): void
+    gracefulShutdown(handler: (signal: string) => Promise<void> | void): void
   }
 }
 
@@ -16,7 +14,11 @@ declare namespace fastifyGracefulShutdown {
   export type fastifyGracefulShutdownOptions = {
     timeout?: number
     resetHandlersOnInit?: boolean
-    handlerEventListener?: EventEmitter & { exit(code?: number): never }
+    useExit0?: boolean
+    handlerEventListener?: EventEmitter & {
+      exit(code?: number): never
+      kill(pid: number, signal?: string | number): boolean
+    }
   }
 
   export const fastifyGracefulShutdown: FastifyGracefulShutdownPlugin

--- a/test.js
+++ b/test.js
@@ -1,8 +1,11 @@
 'use strict'
 
-const Fastify = require('fastify')
-const fastifyGracefulShutdown = require('./')
+const path = require('path')
+const childProcess = require('child_process')
 const { expect } = require('chai')
+const Fastify = require('fastify')
+
+const fastifyGracefulShutdown = require('./')
 
 describe('fastify-graceful-shutdown', () => {
   it('can start and stop multiple instances of fastify', async () => {
@@ -63,6 +66,107 @@ describe('fastify-graceful-shutdown', () => {
 
     expect(addedListeners.length).to.eq(2)
     expect(removedListeners.length).to.eq(0)
+  })
+
+  // Test all default signals with default configuration (exits with received signal)
+  ;['SIGINT', 'SIGTERM'].forEach((killSignal, i) => {
+    ;['50', '300'].forEach((timeout) => {
+      it(`exits with passed signal (${killSignal}) - timeout ${timeout}`, function (done) {
+        this.timeout(10000)
+
+        const shouldTimeout = timeout === '50'
+        const proc = childProcess.fork(path.join(__dirname, 'example.js'), {
+          stdio: 'pipe',
+          env: {
+            ...process.env,
+            GRACEFUL_SHUTDOWN_PORT: `${51093 + i}`,
+            GRACEFUL_SHUTDOWN_DELAY: '100',
+            GRACEFUL_SHUTDOWN_TIMEOUT: timeout,
+          },
+        })
+
+        const logLines = []
+        proc.on('exit', (_, signal) => {
+          expect(signal).to.eq(killSignal)
+          const hasSeenShutdownTimeout = logLines.some((line) =>
+            line.includes('Terminate process after timeout'),
+          )
+          const hasSeenGracefulShutdown = logLines.some((line) =>
+            line.includes('graceful shutdown complete'),
+          )
+          expect(
+            hasSeenGracefulShutdown,
+            'seen graceful shutdown log message',
+          ).to.eq(!shouldTimeout)
+          expect(
+            hasSeenShutdownTimeout,
+            'seen shutdown timeout log message',
+          ).to.eq(shouldTimeout)
+          done()
+        })
+
+        // Send kill signal on first data chunk
+        proc.stdout.once('data', () =>
+          expect(proc.kill(killSignal), `${killSignal} success`).to.eq(true),
+        )
+
+        // See if we've seen the appropriate log message
+        proc.stdout.on('data', (chunk) => {
+          logLines.push(chunk.toString().trim())
+        })
+      })
+    })
+  })
+
+  // Test all default signals with `useExit0` option (exits with 0/1)
+  ;['SIGINT', 'SIGTERM'].forEach((killSignal, i) => {
+    ;['50', '300'].forEach((timeout) => {
+      it(`exits with 0 on 'useExit0: true' option (${killSignal}) - timeout ${timeout}`, function (done) {
+        this.timeout(10000)
+
+        const shouldTimeout = timeout === '50'
+        const proc = childProcess.fork(path.join(__dirname, 'example.js'), {
+          stdio: 'pipe',
+          env: {
+            ...process.env,
+            GRACEFUL_SHUTDOWN_PORT: `${51095 + i}`,
+            GRACEFUL_SHUTDOWN_DELAY: '100',
+            GRACEFUL_SHUTDOWN_USE_EXIT_0: 'true',
+            GRACEFUL_SHUTDOWN_TIMEOUT: timeout,
+          },
+        })
+
+        const logLines = []
+        proc.on('exit', (code) => {
+          expect(code).to.eq(shouldTimeout ? 1 : 0)
+          const hasSeenShutdownTimeout = logLines.some((line) =>
+            line.includes('Terminate process after timeout'),
+          )
+          const hasSeenGracefulShutdown = logLines.some((line) =>
+            line.includes('graceful shutdown complete'),
+          )
+          expect(
+            hasSeenGracefulShutdown,
+            'seen graceful shutdown log message',
+          ).to.eq(!shouldTimeout)
+          expect(
+            hasSeenShutdownTimeout,
+            'seen shutdown timeout log message',
+          ).to.eq(shouldTimeout)
+          done()
+        })
+
+        // Send kill signal on first data chunk
+        proc.stdout.once('data', () =>
+          expect(proc.kill(killSignal), `${killSignal} success`).to.eq(true),
+        )
+
+        // See if we've seen the appropriate log message
+        proc.stdout.on('data', (chunk) => {
+          logLines.push(chunk.toString().trim())
+        })
+      })
+    })
   })
 
   it('work without logger enabled', async () => {


### PR DESCRIPTION
BREAKING CHANGE: Process will now exit with the signal it received, instead of 0/1.

I believe it is more expected for a process to exit with the signal it was passed, rather than exiting with a generic 0 or 1. There are cases where a 0 exit code is wanted, so I added an option to allow for this behavior to continue. Note that I have inverted the default from what it previously was, thus this should be considered a breaking change.

