### PR TITLE
Support afterGracefulShutdown callback, clarify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ fastify.after(() => {
 
 ### `afterGracefulShutdown` — On-close handler
 
-Runs **during** the `onClose` lifecycle, after the server has stopped accepting new connections and all in-flight requests have been drained. Use this for cleanup that is only safe once no more requests are being processed, such as closing database connections, disconnecting from Redis, or flushing buffers.
+Runs **during** the `onClose` lifecycle, after the server has stopped accepting new connections and all in-flight requests have been drained. These handlers **only run when shutdown was triggered by a signal** (`SIGINT`/`SIGTERM`) — they will not run if `fastify.close()` is called directly (e.g., in tests). If you need cleanup that runs on every close regardless of the trigger, use Fastify's built-in `onClose` hook instead. Use this for cleanup that is only safe once no more requests are being processed, such as closing database connections, disconnecting from Redis, or flushing buffers.
 
 ```js
 fastify.after(() => {

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Shutdown [Fastify](https://github.com/fastify/fastify) graceful asynchronously. 
 ## Features
 
 - Graceful and debug friendly shutdown
+- Two-phase shutdown: pre-close handlers (before drain) and on-close handlers (after drain)
 - Flush the fastify logger before process exit to avoid losing logs
 - Handlers are called in parallel for faster shutdown
 
@@ -25,14 +26,43 @@ fastify.register(require('fastify-graceful-shutdown'))
 
 ## Usage
 
+The plugin provides two decorators for registering shutdown handlers that run at different phases:
+
+### `gracefulShutdown` — Immediate signal handler
+
+Runs **immediately** when a shutdown signal (`SIGINT`/`SIGTERM`) is received, before `fastify.close()` is called. At this point the server is still fully operational — it is still accepting new connections and actively processing requests. Use this for actions that should happen before the server starts rejecting requests with 503, such as deregistering from a load balancer or service discovery, stopping message queue consumers, or flipping a health check to unhealthy.
+
 ```js
 fastify.after(() => {
   fastify.gracefulShutdown(async (signal) => {
     fastify.log.info('Received signal to shutdown: %s', signal)
-    await doSomethingAsync()
+    await deregisterFromLoadBalancer()
   })
 })
 ```
+
+### `afterGracefulShutdown` — On-close handler
+
+Runs **during** the `onClose` lifecycle, after the server has stopped accepting new connections and all in-flight requests have been drained. Use this for cleanup that is only safe once no more requests are being processed, such as closing database connections, disconnecting from Redis, or flushing buffers.
+
+```js
+fastify.after(() => {
+  fastify.afterGracefulShutdown(async (signal) => {
+    fastify.log.info('Received signal to shutdown: %s', signal)
+    await db.close()
+  })
+})
+```
+
+### Shutdown order
+
+When a signal is received, the shutdown proceeds in this order:
+
+1. Signal received (`SIGINT`/`SIGTERM`)
+2. **Immediate handlers** (`gracefulShutdown`) run in parallel — server is still fully operational
+3. `fastify.close()` is called — new requests get 503, in-flight requests are drained
+4. **On-close handlers** (`afterGracefulShutdown`) run during the `onClose` lifecycle — all requests are done
+5. Process exits
 
 ## Compatibility
 
@@ -42,5 +72,4 @@ Fastify >=5
 
 - Don't register signal handlers otherwise except with this plugin.
 - Can't be used with a different logger other than [Pino](https://github.com/pinojs/pino) because we use the child logger feature to encapsulate the logs.
-- Use fastify `onClose` hook to release resources in your plugin.
 - The process will be exited after a certain timeout (Default 10 seconds) to protect against stuck process.

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,7 +18,6 @@ declare module 'fastify' {
 declare namespace fastifyGracefulShutdown {
   export type fastifyGracefulShutdownOptions = {
     timeout?: number
-    acceptPreexistingHandlers?: boolean
     resetHandlersOnInit?: boolean
     handlerEventListener?: EventEmitter & { exit(code?: number): never }
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,12 +9,16 @@ declare module 'fastify' {
     gracefulShutdown(
       handler: (signal: string) => Promise<void> | void,
     ): void
+    afterGracefulShutdown(
+      handler: (signal: string) => Promise<void> | void,
+    ): void
   }
 }
 
 declare namespace fastifyGracefulShutdown {
   export type fastifyGracefulShutdownOptions = {
     timeout?: number
+    acceptPreexistingHandlers?: boolean
     resetHandlersOnInit?: boolean
     handlerEventListener?: EventEmitter & { exit(code?: number): never }
   }

--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ function fastifyGracefulShutdown(fastify, opts, next) {
     if (typeof handler !== 'function') {
       throw new Error('Expected a function but got a ' + typeof handler)
     }
-    fastify.addHook('onClose', () => handler(currentSignal))
+    fastify.addHook('onClose', () => {
+      if (currentSignal) return handler(currentSignal)
+    })
   }
 
   fastify.decorate('gracefulShutdown', addHandler)

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,3 +13,5 @@ app.register(plugin)
 
 app.gracefulShutdown((signal: string) => {})
 app.gracefulShutdown(async (signal: string) => {})
+app.afterGracefulShutdown((signal: string) => {})
+app.afterGracefulShutdown(async (signal: string) => {})

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,6 +725,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
       "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -7302,6 +7303,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.11.tgz",
       "integrity": "sha512-kprQpL8MMeszbz6ojB5/tU8PLN4kesnN8Gjzw349rDlNgsSzg90lAVj3llK99Dh7JON+t9AuscPPFW6mPbTnSA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~5.26.4"
       }

--- a/test.js
+++ b/test.js
@@ -39,7 +39,7 @@ describe('fastify-graceful-shutdown', () => {
     let addedListeners = []
     const mockEventListener = {
       removeListener: (signal, listener) => {
-        timeout: 1, removedListeners.push({ signal, listener })
+        timeout: (1, removedListeners.push({ signal, listener }))
       },
       once: (signal, listener) => {
         addedListeners.push({ signal, listener })
@@ -79,5 +79,105 @@ describe('fastify-graceful-shutdown', () => {
 
     await fastify.ready()
     await fastify.close()
+  })
+
+  it('afterGracefulShutdown handler is called during close', async () => {
+    const fastify = Fastify()
+    let handlerCalled = false
+
+    fastify.register(fastifyGracefulShutdown, { resetHandlersOnInit: true })
+
+    fastify.after(() => {
+      fastify.afterGracefulShutdown(async (signal) => {
+        handlerCalled = true
+      })
+    })
+
+    await fastify.ready()
+    await fastify.close()
+
+    expect(handlerCalled).to.eq(true)
+  })
+
+  it('afterGracefulShutdown receives signal when triggered by signal', async function () {
+    this.timeout(10000)
+    const fastify = Fastify()
+    let receivedSignal = null
+
+    const mockEventListener = {
+      removeListener: () => {},
+      once: (signal, listener) => {
+        if (signal === 'SIGTERM') {
+          // simulate signal after registration
+          setTimeout(() => listener(), 50)
+        }
+      },
+      listenerCount: () => 0,
+      exit: () => {},
+    }
+
+    fastify.register(fastifyGracefulShutdown, {
+      handlerEventListener: mockEventListener,
+    })
+
+    fastify.after(() => {
+      fastify.afterGracefulShutdown(async (signal) => {
+        receivedSignal = signal
+      })
+    })
+
+    await fastify.ready()
+
+    // wait for the simulated signal to trigger shutdown
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(receivedSignal).to.eq('SIGTERM')
+  })
+
+  it('gracefulShutdown runs before afterGracefulShutdown', async function () {
+    this.timeout(10000)
+    const fastify = Fastify()
+    const order = []
+
+    const mockEventListener = {
+      removeListener: () => {},
+      once: (signal, listener) => {
+        if (signal === 'SIGTERM') {
+          setTimeout(() => listener(), 50)
+        }
+      },
+      listenerCount: () => 0,
+      exit: () => {},
+    }
+
+    fastify.register(fastifyGracefulShutdown, {
+      handlerEventListener: mockEventListener,
+    })
+
+    fastify.after(() => {
+      fastify.gracefulShutdown(async (signal) => {
+        order.push('pre-close')
+      })
+      fastify.afterGracefulShutdown(async (signal) => {
+        order.push('on-close')
+      })
+    })
+
+    await fastify.ready()
+
+    await new Promise((resolve) => setTimeout(resolve, 200))
+
+    expect(order).to.deep.eq(['pre-close', 'on-close'])
+  })
+
+  it('afterGracefulShutdown throws on non-function argument', async () => {
+    const fastify = Fastify()
+    fastify.register(fastifyGracefulShutdown, { resetHandlersOnInit: true })
+
+    await fastify.ready()
+
+    expect(() => fastify.afterGracefulShutdown('not a function')).to.throw(
+      'Expected a function but got a string',
+    )
   })
 })

--- a/test.js
+++ b/test.js
@@ -81,7 +81,7 @@ describe('fastify-graceful-shutdown', () => {
     await fastify.close()
   })
 
-  it('afterGracefulShutdown handler is called during close', async () => {
+  it('afterGracefulShutdown does not run on direct fastify.close()', async () => {
     const fastify = Fastify()
     let handlerCalled = false
 
@@ -96,7 +96,7 @@ describe('fastify-graceful-shutdown', () => {
     await fastify.ready()
     await fastify.close()
 
-    expect(handlerCalled).to.eq(true)
+    expect(handlerCalled).to.eq(false)
   })
 
   it('afterGracefulShutdown receives signal when triggered by signal', async function () {


### PR DESCRIPTION
Current behaviour is likely not what majority of users are going to expect - callback is only for preparing/starting graceful shutdown, but not for wrapping things up after requests were drained and no new ones are going to arrive. Clarified documentation and provided a new callback for those who need post-shutdown hook for graceful termination cases.

fixes #56